### PR TITLE
Update constexpr_any using function table to copy, destroy and get type id

### DIFF
--- a/include/constexpr_any.h
+++ b/include/constexpr_any.h
@@ -23,52 +23,73 @@ namespace mr {
         struct is_specialization : std::bool_constant< is_specialization_v< Type, Template > > {};
 
         struct any_type_base {
+            // constexpr std::type_info-like utility
+            using TypeId = const std::uint8_t*;
+
             constexpr any_type_base() = default;
             constexpr virtual ~any_type_base() {
             }
-
-            constexpr virtual any_type_base* do_copy() const       = 0;
-            constexpr virtual void           do_destroy() noexcept = 0;
         };
 
         template < class T >
         struct [[nodiscard]] any_type : public any_type_base {
           public:
+            // constexpr std::type_info-like utility
+            inline static constexpr std::uint8_t Type_id = 0;
+
             using Base = any_type_base;
 
             template < class... Args >
             explicit constexpr any_type(Args&&... args) : data(std::forward< Args >(args)...) {
             }
 
-            constexpr virtual ~any_type() {
-            }
+            constexpr any_type(const any_type&) = default;
 
-            [[nodiscard]] constexpr Base* do_copy() const override {
-                static_assert(std::copy_constructible< T >);
-                any_type* new_type = new any_type { data };
-                return static_cast< Base* >(new_type);
+            constexpr virtual ~any_type() {
             }
 
             [[nodiscard]] constexpr T* get_data() noexcept {
                 return std::addressof(data);
             }
 
-            constexpr void do_destroy() noexcept override {
-                delete this;
+            [[nodiscard]] constexpr const T* get_data() const noexcept {
+                return std::addressof(data);
             }
 
           private:
             T data;
         };
 
-        // constexpr std::type_info-like utility
-        template < class T >
-        inline static constexpr std::uint8_t Type_id = 0;
+        struct Any_type_table {
+            using DestroyFn = void (*)(any_type_base*) noexcept;
+            using CopyFn    = any_type_base* (*)(const any_type_base*) noexcept;
+            using TypeIdFn  = any_type_base::TypeId (*)() noexcept;
+
+            template < class T >
+            static constexpr void Destroy(any_type_base* ptr) noexcept {
+                ::delete static_cast< any_type< T >* >(ptr);
+            }
+
+            template < class T >
+            static constexpr any_type_base* Copy(const any_type_base* ptr) noexcept {
+                static_assert(std::copy_constructible< T >);
+                return ::new any_type< T >(*static_cast< const any_type< T >* >(ptr));
+            }
+
+            template < class T >
+            static constexpr any_type_base::TypeId TypeID() noexcept {
+                return std::addressof(any_type< T >::Type_id);
+            }
+
+            DestroyFn do_destroy;
+            CopyFn    do_copy;
+            TypeIdFn  get_typeid;
+        };
 
         template < class T >
-        static constexpr const std::uint8_t* GetTypeId() noexcept {
-            return std::addressof(Type_id< std::decay_t< T > >);
-        }
+        inline constexpr Any_type_table any_type_table = { std::addressof(Any_type_table::Destroy< T >),
+                                                           std::addressof(Any_type_table::Copy< T >),
+                                                           std::addressof(Any_type_table::TypeID< T >) };
 
     } // namespace detail
 
@@ -80,8 +101,8 @@ namespace mr {
             if (std::addressof(rhs) != this) {
                 if (std::is_constant_evaluated()) {
                     if (rhs.has_value()) {
-                        data.constexprData.ptr = rhs.data.constexprData.ptr->do_copy();
-                        data.constexprData.id  = rhs.data.constexprData.id;
+                        data.constexprData.table = rhs.data.constexprData.table;
+                        data.constexprData.ptr   = data.constexprData.table->do_copy(rhs.data.constexprData.ptr);
                     }
                 } else {
                     std::construct_at(std::addressof(get_std_any()), rhs.get_std_any());
@@ -186,10 +207,10 @@ namespace mr {
 
         constexpr void reset() noexcept {
             if (std::is_constant_evaluated()) {
-                if (data.constexprData.ptr) {
-                    data.constexprData.ptr->do_destroy();
-                    data.constexprData.ptr = nullptr;
-                    data.constexprData.id  = 0;
+                if (has_value()) {
+                    data.constexprData.table->do_destroy(data.constexprData.ptr);
+                    data.constexprData.ptr   = nullptr;
+                    data.constexprData.table = nullptr;
                 }
             } else {
                 get_std_any().reset();
@@ -211,10 +232,10 @@ namespace mr {
         template < class T >
         [[nodiscard]] constexpr const T* cast_to() const noexcept {
             if (std::is_constant_evaluated()) {
-                if (data.constexprData.id == detail::GetTypeId< T >()) {
-                    return static_cast< detail::any_type< T >* >(data.constexprData.ptr)->get_data();
+                if (!has_value() || data.constexprData.table->get_typeid() != detail::Any_type_table::TypeID< T >()) {
+                    return nullptr;
                 }
-                return nullptr;
+                return static_cast< const detail::any_type< T >* >(data.constexprData.ptr)->get_data();
             } else {
                 return std::any_cast< T >(std::addressof(get_std_any()));
             }
@@ -223,10 +244,10 @@ namespace mr {
         template < class T >
         [[nodiscard]] constexpr T* cast_to() noexcept {
             if (std::is_constant_evaluated()) {
-                if (data.constexprData.id == detail::GetTypeId< T >()) {
-                    return static_cast< detail::any_type< T >* >(data.constexprData.ptr)->get_data();
+                if (!has_value() || data.constexprData.table->get_typeid() != detail::Any_type_table::TypeID< T >()) {
+                    return nullptr;
                 }
-                return nullptr;
+                return static_cast< detail::any_type< T >* >(data.constexprData.ptr)->get_data();
             } else {
                 return std::any_cast< T >(std::addressof(get_std_any()));
             }
@@ -255,20 +276,20 @@ namespace mr {
 
       private:
         struct ConstexprData {
-            constexpr ConstexprData() : ptr(nullptr), id(nullptr) {
+            constexpr ConstexprData() : ptr(nullptr), table(nullptr) {
             }
             constexpr ~ConstexprData() {
             }
 
-            detail::any_type_base* ptr;
-            const std::uint8_t*    id;
+            detail::any_type_base*        ptr;
+            const detail::Any_type_table* table;
         };
 
         template < class DType, class... Args >
         inline constexpr DType& do_emplace(Args&&... args) {
             detail::any_type< DType >* type = new detail::any_type< DType >(std::forward< Args >(args)...);
             data.constexprData.ptr          = type;
-            data.constexprData.id           = detail::GetTypeId< DType >();
+            data.constexprData.table        = std::addressof(detail::any_type_table< DType >);
             return *(type->get_data());
         }
 
@@ -282,11 +303,11 @@ namespace mr {
         }
 
         [[nodiscard]] inline const std::any& get_std_any() const noexcept {
-            return *reinterpret_cast< const std::any* >(&data.any);
+            return *reinterpret_cast< const std::any* >(std::addressof(data.any));
         }
 
         [[nodiscard]] inline std::any& get_std_any() noexcept {
-            return *reinterpret_cast< std::any* >(&data.any);
+            return *reinterpret_cast< std::any* >(std::addressof(data.any));
         }
 
         union Data {
@@ -298,13 +319,14 @@ namespace mr {
                 if (std::is_constant_evaluated()) {
                     std::construct_at(&constexprData);
                 } else {
-                    std::construct_at(reinterpret_cast< std::any* >(&any));
+                    std::construct_at(reinterpret_cast< std::any* >(std::addressof(any)));
                 }
             }
 
             constexpr ~Data() {
             }
         };
+        static_assert(sizeof(Data) == sizeof(std::any));
 
         Data data {};
     };
@@ -359,7 +381,7 @@ namespace mr {
                       "any_cast<T>(const any&) requires std::remove_cv_t<T> to be constructible from "
                       "const std::remove_cv_t<std::remove_reference_t<T>>&");
 
-        const auto ptr = any_cast< std::remove_cvref_t< T > >(&value);
+        const auto ptr = any_cast< std::remove_cvref_t< T > >(std::addressof(value));
         if (!ptr) {
             throw std::bad_any_cast {};
         }
@@ -373,7 +395,7 @@ namespace mr {
                       "any_cast<T>(any&) requires std::remove_cv_t<T> to be constructible from "
                       "std::remove_cv_t<std::remove_reference_t<T>>&");
 
-        const auto ptr = any_cast< std::remove_cvref_t< T > >(&value);
+        const auto ptr = any_cast< std::remove_cvref_t< T > >(std::addressof(value));
         if (!ptr) {
             throw std::bad_any_cast {};
         }
@@ -387,7 +409,7 @@ namespace mr {
                       "any_cast<T>(any&&) requires std::remove_cv_t<T> to be constructible from "
                       "std::remove_cv_t<std::remove_reference_t<T>>");
 
-        const auto ptr = any_cast< std::remove_cvref_t< T > >(&value);
+        const auto ptr = any_cast< std::remove_cvref_t< T > >(std::addressof(value));
         if (!ptr) {
             throw std::bad_any_cast {};
         }

--- a/tests/constexpr_any/source.cpp
+++ b/tests/constexpr_any/source.cpp
@@ -330,8 +330,6 @@ namespace test {
 static_assert(test::TestDestroy< test_helpers::Object< test_helpers::SmallSizeObject > >());
 static_assert(test::TestDestroy< test_helpers::Object< test_helpers::LargeSizeObject > >());
 
-#ifndef _MSC_VER // Reported:
-                 // https://developercommunity.visualstudio.com/t/constexpr-polymorphism-does-not-work-when-accessin/1634413
 static_assert(test::TestCopy< test_helpers::Object< test_helpers::SmallSizeObject >,
                               test_helpers::Object< test_helpers::SmallSizeObject > >());
 static_assert(test::TestCopy< test_helpers::Object< test_helpers::LargeSizeObject >,
@@ -340,7 +338,6 @@ static_assert(test::TestCopy< test_helpers::Object< test_helpers::SmallSizeObjec
                               test_helpers::Object< test_helpers::LargeSizeObject > >());
 static_assert(test::TestCopy< test_helpers::Object< test_helpers::LargeSizeObject >,
                               test_helpers::Object< test_helpers::SmallSizeObject > >());
-#endif // _MSC_VER
 
 static_assert(test::TestMove< test_helpers::Object< test_helpers::SmallSizeObject >,
                               test_helpers::Object< test_helpers::SmallSizeObject > >());


### PR DESCRIPTION
This PR implements a function table to copy, delete and get typeid.
The main reason is to workaround the MSVC compiler bug that does not allow accessing data members from a virtual functions using a parent pointer.